### PR TITLE
fixed issue #1555

### DIFF
--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -22,6 +22,11 @@ var OfflineFlags = map[string]string{
 	// "experimental-licenses": "", // StringSliceFlag has to be manually cleared.
 }
 
+// sets default port(8000) as a global variable
+var (
+    servePort = "8000"  // default port
+)
+
 var GlobalScanFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:      "config",
@@ -44,6 +49,14 @@ var GlobalScanFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  "serve",
 		Usage: "output as HTML result and serve it locally",
+	},
+	&cli.StringFlag{
+		Name:  "port",
+		Usage: "port number to use when serving HTML report (default: 8000)",
+		Action: func(_ *cli.Context, p string) error {
+            servePort = p
+            return nil
+        },
 	},
 	&cli.StringFlag{
 		Name:      "output",
@@ -129,7 +142,6 @@ func OpenHTML(r reporter.Reporter, outputPath string) {
 // The program will keep running to serve the HTML report on localhost
 // until the user manually terminates it (e.g. using Ctrl+C).
 func ServeHTML(r reporter.Reporter, outputPath string) {
-	servePort := "8000"
 	localhostURL := fmt.Sprintf("http://localhost:%s/", servePort)
 	r.Infof("Serving HTML report at %s.\nIf you are accessing remotely, use the following SSH command:\n`ssh -L local_port:destination_server_ip:%s ssh_server_hostname`\n", localhostURL, servePort)
 	server := &http.Server{


### PR DESCRIPTION
1.Added a global variable servePort with a default value of "8000"

2.Added a new CLI flag --port that allows users to customize the port number used when serving the HTML report

3. Removed the hardcoded port number from the ServeHTML function, using the global servePort variable instead

4. The flag's Action function updates the global servePort variable when a custom port is specified

These changes allow users to specify a custom port using the --port flag when using the --serve option, while maintaining the default port 8000 if no custom port is specified.